### PR TITLE
Modify loadgen to overwrite the command

### DIFF
--- a/acme-fe-be-split/acme-fe/loadgen.yaml
+++ b/acme-fe-be-split/acme-fe/loadgen.yaml
@@ -33,29 +33,48 @@ spec:
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
       initContainers:
-      - name: wait-frontend
-        image: alpine:3.7
-        command: ['sh', '-c', 'echo -e "http://nl.alpinelinux.org/alpine/v3.5/main\nhttp://nl.alpinelinux.org/alpine/v3.5/community" > /etc/apk/repositories' , 'set -x;  apk update ; apk add curl && 
-          until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do 
-            echo "waiting for http://${FRONTEND_ADDR}"; 
-            sleep 2;
-          done;']
-        env:
-        - name: FRONTEND_ADDR
-          value: "shopping:80"
+        - name: wait-frontend
+          image: alpine:3.7
+          command: [
+              "sh",
+              "-c",
+              'echo -e "http://nl.alpinelinux.org/alpine/v3.5/main\nhttp://nl.alpinelinux.org/alpine/v3.5/community" > /etc/apk/repositories',
+              'set -x;  apk update ; apk add curl &&
+              until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do
+              echo "waiting for http://${FRONTEND_ADDR}";
+              sleep 2;
+              done;',
+            ]
+          env:
+            - name: FRONTEND_ADDR
+              value: "shopping:80"
       containers:
-      - name: main
-        image: docker.io/vmwareallspark/acme-load-gen:latest
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8089
-        env:
-        - name: FRONTEND_ADDR
-          value: "shopping:80"
-        resources:
-          requests:
-            cpu: 300m
-            memory: 256Mi
-          limits:
-            cpu: 500m
-            memory: 512Mi
+        - name: main
+          image: docker.io/vmwareallspark/acme-load-gen:latest
+          imagePullPolicy: Always
+          command:
+            [
+              "/usr/local/bin/python",
+              "/usr/local/bin/locust",
+              "--host",
+              "http://$FRONTEND_ADDR",
+              "-c",
+              "10",
+              "-r",
+              "100",
+              "--no-web",
+              "-L",
+              "CRITICAL",
+            ]
+          ports:
+            - containerPort: 8089
+          env:
+            - name: FRONTEND_ADDR
+              value: "shopping:80"
+          resources:
+            requests:
+              cpu: 300m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi


### PR DESCRIPTION
The Loadgen generates a high log volume which often results in disk pressure and leads to evicted pods. 
I modify the loadgen workload config to overwrite the container's command to set the log level to CRITICAL.